### PR TITLE
Change branch for xdmod-introspection to main

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -48,7 +48,7 @@
     <project
         name="xdmod-introspection"
         groups="introspection"
-        revision="master"
+        revision="main"
     >
         <linkfile src="." dest="xdmod/open_xdmod/modules/introspection" />
     </project>


### PR DESCRIPTION
The master branch does not exist for the xdmod-introspection module, main is the correct name of the branch.