### PR TITLE
Adding Cloudbank Module

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -5,6 +5,11 @@
         alias="upstream"
         fetch="https://github.com/ubccr"
     />
+    <remote
+            name="github-ryanrath"
+            alias="ryanrath"
+            fetch="https://github.com/ryanrath"
+    />
     <default
         remote="ubccr"
         revision="main"
@@ -55,6 +60,14 @@
         groups="xsede"
     >
         <linkfile src="." dest="xdmod/open_xdmod/modules/xsede" />
+    </project>
+    <project
+            name="xdmod-cloudbank"
+            groups="cloudbank"
+            remote="github-ryanrath"
+            revision="initial-version"
+    >
+        <linkfile src="." dest="xdmod/open_xdmod/modules/cloudbank"/>
     </project>
     <!--
     Related Tools


### PR DESCRIPTION
This PR adds the new xdmod-cloudbank module to the set of modules that can be checked out / installed. 

**Note: For the moment it is pointing at my personal repo. But after xdmod-cloudbank has been approved then it will be changed to point at the ubccr repo**
