### PR TITLE
Updating xdmod-cloudbank branch

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -65,7 +65,7 @@
             name="xdmod-cloudbank"
             groups="cloudbank"
             remote="ryanrath"
-            revision="update-dimension-tables"
+            revision="main"
     >
         <linkfile src="." dest="xdmod/open_xdmod/modules/cloudbank" />
     </project>


### PR DESCRIPTION
We now have most of the xdmod-cloudbank changes into main so we should use that branch for now.