### PR TITLE
Changing branch to re-add-organization-attributes

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -65,7 +65,7 @@
             name="xdmod-cloudbank"
             groups="cloudbank"
             remote="github-ryanrath"
-            revision="merge-udt-and-afr"
+            revision="re-add-organization-attributes"
     >
         <linkfile src="." dest="xdmod/open_xdmod/modules/cloudbank"/>
     </project>


### PR DESCRIPTION
Just changing the xdmod-cloudbank branch to be installed on xdmod-dev to `re-add-organization-attributes`. This branch contains the contents of `update_dimension_tables` as well as new groupbys for the institution dimension: 
- Carnegie Classification
- Carnegie Research Designation
- Epscor Status
- City
- State
- Country

